### PR TITLE
Adding one parameter to deployment parameters file

### DIFF
--- a/2_deploy/aadHybridIdentityADFS/azuredeploy.parameters.json
+++ b/2_deploy/aadHybridIdentityADFS/azuredeploy.parameters.json
@@ -20,6 +20,9 @@
         "adfsPassword": {
             "value": "GEN-PASSWORD"
         },
+        "domainFQDN": {
+            "value": "Example: 'YOUR-DOMAIN.TLD'. DO NOT use '*.YOUR-DOMAIN.TLD' as the wildcard is added later on."
+        },
         "domainUsers": {
             "value": {
                 "array": [

--- a/2_deploy/aadHybridIdentityADFS/azuredeploy.parameters.json
+++ b/2_deploy/aadHybridIdentityADFS/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
             "value": "GEN-PASSWORD"
         },
         "domainFQDN": {
-            "value": "Example: 'YOUR-DOMAIN.TLD'. DO NOT use '*.YOUR-DOMAIN.TLD' as the wildcard is added later on."
+            "value": "The FQDN of the Active Directory Domain to be created"
         },
         "domainUsers": {
             "value": {


### PR DESCRIPTION
In attempting to build the environment using the supplied azuredeploy.paramenters.json I noticed the InstallADFS sub-deployment was failing, this was due to the $cert variable in InstallADFS.ps1 being blank, as the domainFQDN eventually passed as a parameter was not present. Adding it here along with a cautionary note to avoid placing the wildcard, as installADFS.ps1 does this alrady.