### PR TITLE
Small Fix in Helper Doc

### DIFF
--- a/2_deploy/_helper_docs/registerAADAppAndSP.md
+++ b/2_deploy/_helper_docs/registerAADAppAndSP.md
@@ -17,7 +17,8 @@ az login
 
 ```PowerShell
 $appName = "SimuLandApp"
-$results= az ad app create --display-name $appname --homepage "https://localhost/$appname" --reply-urls "https://localhost/$appname" --identifier-uris "https://localhost/$appname"
+$domainName = "DOMAIN.COM"
+$results= az ad app create --display-name $appname --homepage "https://$domainName/$appname" --reply-urls "https://$domainName/$appname" --identifier-uris "https://$domainName/$appname"
 $app = $results | ConvertFrom-Json
 $app
 ```


### PR DESCRIPTION
The change to require identifier URIs to be a verified domain seems to be enforced now, making the app registration fail with error 'Values of identifierUris property must use a verified domain of the organisation or its subdomain'.

Made the rest of the parameters consistent.

ref: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains